### PR TITLE
DEV-20325: volume-scanner Cloud Shell installer

### DIFF
--- a/volume-scanner/setup.sh
+++ b/volume-scanner/setup.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+#
+# Stream Security — GCP agentless volume scanner — Cloud Shell installer
+# (DEV-20325).
+#
+# Parameterized counterpart of the server-rendered scanner-setup.sh.jinja2.
+# Designed to run from the "Open in Cloud Shell" tutorial: the user exports a
+# few values shown in the Stream console (mirroring the GCP project onboarding
+# flow), then runs this. Idempotent: re-running updates in place.
+#
+# Required (exported by the walkthrough; shown in the Stream console):
+#   STREAM_API_URL          e.g. https://<tenant>.<domain>
+#   STREAM_ACK_TOKEN        per-deployment acknowledge token
+#   STREAM_COLLECTION_TOKEN per-customer collection token
+#   STREAM_CUSTOMER_ID      workspace (customer) id
+# Optional (sensible defaults):
+#   PROJECT_ID              defaults to the active Cloud Shell project
+#   REGION                  defaults to us-central1
+#   SCANNER_IMAGE           defaults to the public scanner image :latest
+set -euo pipefail
+
+PROJECT_ID="${PROJECT_ID:-$(gcloud config get-value project 2>/dev/null)}"
+REGION="${REGION:-us-central1}"
+SCANNER_IMAGE="${SCANNER_IMAGE:-public.ecr.aws/stream-security/volume-scanner:latest}"
+
+: "${STREAM_API_URL:?export STREAM_API_URL (from the Stream console)}"
+: "${STREAM_ACK_TOKEN:?export STREAM_ACK_TOKEN (from the Stream console)}"
+: "${STREAM_COLLECTION_TOKEN:?export STREAM_COLLECTION_TOKEN (from the Stream console)}"
+: "${STREAM_CUSTOMER_ID:?export STREAM_CUSTOMER_ID (from the Stream console)}"
+: "${PROJECT_ID:?no active project — run: gcloud config set project <PROJECT_ID>}"
+
+SA_NAME="streamsec-volume-scanner"
+SA_EMAIL="${SA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com"
+ROLE_ID="streamsec.volumeScanner"
+JOB_NAME="streamsec-volume-scanner-orchestrator"
+SCHEDULER_NAME="streamsec-volume-scanner-cron"
+
+echo "Stream Security volume scanner -> project ${PROJECT_ID}, region ${REGION}"
+
+# 1. Enable the APIs the scanner uses.
+gcloud services enable \
+  compute.googleapis.com batch.googleapis.com run.googleapis.com cloudscheduler.googleapis.com \
+  --project "${PROJECT_ID}"
+
+# 2. Service account (single SA for orchestrator + worker).
+gcloud iam service-accounts describe "${SA_EMAIL}" --project "${PROJECT_ID}" >/dev/null 2>&1 || \
+  gcloud iam service-accounts create "${SA_NAME}" \
+    --display-name="Stream Security volume scanner" --project "${PROJECT_ID}"
+
+# 3. Custom least-privilege role (discover + Batch + snapshot/disk).
+cat > /tmp/streamsec-scanner-role.yaml <<'ROLE'
+title: "Stream Security Volume Scanner"
+description: "Agentless disk scanning: discover VMs, snapshot/attach disks, run Batch workers."
+stage: "GA"
+includedPermissions:
+- compute.instances.list
+- compute.instances.get
+- compute.instances.attachDisk
+- compute.instances.detachDisk
+- compute.disks.create
+- compute.disks.get
+- compute.disks.use
+- compute.disks.delete
+- compute.snapshots.create
+- compute.snapshots.get
+- compute.snapshots.useReadOnly
+- compute.snapshots.delete
+- batch.jobs.create
+- batch.jobs.get
+- batch.jobs.delete
+- iam.serviceAccounts.actAs
+- logging.logEntries.create
+ROLE
+
+if gcloud iam roles describe "${ROLE_ID}" --project "${PROJECT_ID}" >/dev/null 2>&1; then
+  gcloud iam roles update "${ROLE_ID}" --project "${PROJECT_ID}" --file=/tmp/streamsec-scanner-role.yaml
+else
+  gcloud iam roles create "${ROLE_ID}" --project "${PROJECT_ID}" --file=/tmp/streamsec-scanner-role.yaml
+fi
+
+gcloud projects add-iam-policy-binding "${PROJECT_ID}" \
+  --member="serviceAccount:${SA_EMAIL}" \
+  --role="projects/${PROJECT_ID}/roles/${ROLE_ID}" --condition=None
+
+# 4. Orchestrator Cloud Run Job (workers are created at runtime as Batch jobs).
+gcloud run jobs deploy "${JOB_NAME}" \
+  --image="${SCANNER_IMAGE}" --region="${REGION}" --service-account="${SA_EMAIL}" \
+  --set-env-vars="COLLECTOR_PROVIDER=gcp,COLLECTOR_ROLE=orchestrator,COLLECTOR_GCP_PROJECT=${PROJECT_ID},COLLECTOR_GCP_REGION=${REGION},COLLECTOR_GCP_WORKER_IMAGE=${SCANNER_IMAGE},COLLECTOR_GCP_WORKER_SA=${SA_EMAIL},STREAM_SCAN_URL=${STREAM_API_URL}/openapi/vulnerabilities/stream_scan/raw,COLLECTION_TOKEN=${STREAM_COLLECTION_TOKEN}" \
+  --project "${PROJECT_ID}"
+
+# 5. Cloud Scheduler cron -> trigger the orchestrator daily.
+RUN_URI="https://${REGION}-run.googleapis.com/apis/run.googleapis.com/v1/namespaces/${PROJECT_ID}/jobs/${JOB_NAME}:run"
+if gcloud scheduler jobs describe "${SCHEDULER_NAME}" --location="${REGION}" --project "${PROJECT_ID}" >/dev/null 2>&1; then
+  SCHED_VERB="update http"
+else
+  SCHED_VERB="create http"
+fi
+gcloud scheduler jobs ${SCHED_VERB} "${SCHEDULER_NAME}" \
+  --location="${REGION}" --schedule="0 2 * * *" --uri="${RUN_URI}" \
+  --http-method=POST --oauth-service-account-email="${SA_EMAIL}" --project "${PROJECT_ID}"
+
+# 6. Acknowledge the install back to Stream Security.
+curl -fsS -X POST "${STREAM_API_URL}/api/accounts/${PROJECT_ID}/gcp-scanner-acknowledge" \
+  -H "Content-Type: application/json" \
+  -d "{\"customer_id\":\"${STREAM_CUSTOMER_ID}\",\"project_id\":\"${PROJECT_ID}\",\"status\":\"deployed\",\"acknowledge_token\":\"${STREAM_ACK_TOKEN}\"}" \
+  || echo "WARNING: acknowledge callback failed; scanner deployed but console may show 'pending'."
+
+echo "Done. Stream Security volume scanner deployed to ${PROJECT_ID}."

--- a/volume-scanner/walkthrough.md
+++ b/volume-scanner/walkthrough.md
@@ -1,0 +1,63 @@
+# Deploy the Stream Security volume scanner
+
+This guides you through deploying the Stream Security **agentless volume
+scanner** into your GCP project. It provisions a least-privilege service
+account, a Cloud Run orchestrator (on a daily Cloud Scheduler trigger), and
+runs per-VM scans as GCP Batch jobs. Nothing leaves your project except the
+package inventory sent to Stream Security.
+
+## Prerequisites
+
+<walkthrough-project-setup></walkthrough-project-setup>
+
+Make sure the project above is the one you want scanned. To change it:
+
+```bash
+gcloud config set project <PROJECT_ID>
+```
+
+## Step 1 — Paste the values from the Stream console
+
+In the Stream Security console, on the scanner **Deploy** panel, copy the four
+values shown and paste them here (they authenticate the install back to your
+tenant):
+
+```bash
+export STREAM_API_URL="<Environment URL>"
+export STREAM_CUSTOMER_ID="<Workspace ID>"
+export STREAM_ACK_TOKEN="<Acknowledge token>"
+export STREAM_COLLECTION_TOKEN="<Collection token>"
+```
+
+Optional — override the region (default `us-central1`) or pin a specific
+scanner image:
+
+```bash
+export REGION="us-central1"
+# export SCANNER_IMAGE="public.ecr.aws/stream-security/volume-scanner:vX.Y.Z"
+```
+
+## Step 2 — Run the installer
+
+```bash
+bash ./setup.sh
+```
+
+This enables the required APIs, creates the `streamsec-volume-scanner` service
+account + custom role, deploys the orchestrator Cloud Run Job + Cloud Scheduler
+cron, and acknowledges the install.
+
+## Step 3 — (Optional) run a scan now
+
+The scanner runs daily at 02:00 by default. To run immediately:
+
+```bash
+gcloud run jobs execute streamsec-volume-scanner-orchestrator --region "${REGION:-us-central1}"
+```
+
+## Done
+
+<walkthrough-conclusion-trophy></walkthrough-conclusion-trophy>
+
+Back in the Stream Security console the scanner status will move to
+**Deployed**, then **Active** after the first scan completes.


### PR DESCRIPTION
Adds a `volume-scanner/` Cloud Shell installer (walkthrough + parameterized `setup.sh`) for the Stream Security agentless volume scanner — the GCP "comfortable install" analog of AWS quickcreate / Azure "Deploy to Azure", mirroring the existing GCP onboarding tutorial in this repo.

The Stream console's scanner **Deploy** button opens this via:
`shell.cloud.google.com/cloudshell/editor?cloudshell_git_repo=…/gcp-deploymentmanager&cloudshell_workspace=volume-scanner&cloudshell_tutorial=walkthrough.md`

The user exports per-tenant values (shown in the console: API URL, customer id, ack + collection tokens), then runs `setup.sh`, which provisions the SA + custom role, the orchestrator Cloud Run Job + Cloud Scheduler cron, and acknowledges the install.

Companion: lightlytics `dev-20325-gcp-scanner-support` (backend/UI wiring).

🤖 Generated with [Claude Code](https://claude.com/claude-code)