### PR TITLE
DEV-20325: volume-scanner Infrastructure Manager blueprint

### DIFF
--- a/volume-scanner/README.md
+++ b/volume-scanner/README.md
@@ -28,6 +28,32 @@ as; it needs permission to create the resources above (e.g. roles/editor +
 roles/resourcemanager.projectIamAdmin, or a scoped equivalent). See the Stream
 docs for the recommended setup.
 
+### One-time: create the runner service account
+
+Run once per project (the Stream console's Deploy dialog also shows this). It
+needs project IAM-admin, since the blueprint creates a custom role + IAM
+binding:
+
+```bash
+PROJECT=<PROJECT_ID>
+SA=infra-manager@$PROJECT.iam.gserviceaccount.com
+PROJNUM=$(gcloud projects describe $PROJECT --format='value(projectNumber)')
+
+gcloud iam service-accounts create infra-manager --display-name="Infra Manager runner" 2>/dev/null || true
+
+for ROLE in roles/editor roles/iam.roleAdmin roles/resourcemanager.projectIamAdmin; do
+  gcloud projects add-iam-policy-binding $PROJECT --member="serviceAccount:$SA" --role="$ROLE" --condition=None -q
+done
+
+# let the Infrastructure Manager service agent use the runner SA
+gcloud iam service-accounts add-iam-policy-binding $SA \
+  --member="serviceAccount:service-$PROJNUM@gcp-sa-config.iam.gserviceaccount.com" \
+  --role="roles/iam.serviceAccountTokenCreator" -q
+```
+
+Then pass `--service-account=projects/$PROJECT/serviceAccounts/$SA` to the
+`apply` command above.
+
 ## Inputs
 
 See `variables.tf`.

--- a/volume-scanner/README.md
+++ b/volume-scanner/README.md
@@ -41,9 +41,11 @@ PROJNUM=$(gcloud projects describe $PROJECT --format='value(projectNumber)')
 
 gcloud iam service-accounts create infra-manager --display-name="Infra Manager runner" 2>/dev/null || true
 
-for ROLE in roles/editor roles/iam.roleAdmin roles/resourcemanager.projectIamAdmin; do
+for ROLE in roles/editor roles/iam.roleAdmin roles/resourcemanager.projectIamAdmin roles/config.agent; do
   gcloud projects add-iam-policy-binding $PROJECT --member="serviceAccount:$SA" --role="$ROLE" --condition=None -q
 done
+# roles/config.agent is required — Infra Manager's Terraform state backend calls
+# config.deployments.getState as this SA; without it, `tf init` fails.
 
 # let the Infrastructure Manager service agent use the runner SA
 gcloud iam service-accounts add-iam-policy-binding $SA \

--- a/volume-scanner/README.md
+++ b/volume-scanner/README.md
@@ -1,0 +1,33 @@
+# Stream Security volume scanner — Infrastructure Manager blueprint
+
+Terraform blueprint for the Stream Security agentless volume scanner, deployed
+via **GCP Infrastructure Manager** (the successor to the now-EOL Deployment
+Manager), matching how the Stream GCP integration onboards.
+
+It provisions a least-privilege service account + custom role, an orchestrator
+Cloud Run Job on a daily Cloud Scheduler trigger, and acknowledges the install
+back to Stream. Per-VM scans run as GCP Batch jobs created at runtime.
+
+## Deploy
+
+The Stream console (scanner **Deploy** dialog) renders a pre-filled command.
+It looks like:
+
+```bash
+gcloud infra-manager deployments apply \
+  projects/<PROJECT_ID>/locations/<REGION>/deployments/streamsec-volume-scanner \
+  --service-account=projects/<PROJECT_ID>/serviceAccounts/<INFRA_MANAGER_SA> \
+  --git-source-repo=https://github.com/lightlytics/gcp-deploymentmanager \
+  --git-source-directory=volume-scanner \
+  --git-source-ref=master \
+  --input-values=project_id=<PROJECT_ID>,region=<REGION>,scanner_image=<IMAGE>,stream_api_url=<API_URL>,stream_customer_id=<CUSTOMER_ID>,stream_ack_token=<ACK_TOKEN>,stream_collection_token=<COLLECTION_TOKEN>
+```
+
+`<INFRA_MANAGER_SA>` is a service account Infrastructure Manager runs Terraform
+as; it needs permission to create the resources above (e.g. roles/editor +
+roles/resourcemanager.projectIamAdmin, or a scoped equivalent). See the Stream
+docs for the recommended setup.
+
+## Inputs
+
+See `variables.tf`.

--- a/volume-scanner/main.tf
+++ b/volume-scanner/main.tf
@@ -64,6 +64,11 @@ resource "google_project_iam_custom_role" "scanner" {
     "compute.snapshots.get",
     "compute.snapshots.useReadOnly",
     "compute.snapshots.delete",
+    # Use the scanner's own subnet (below) for the Batch worker VM. Granted via
+    # this project-level role rather than a subnet-scoped IAM binding, so the
+    # runner SA only needs its documented roles (editor + projectIamAdmin) and
+    # not compute.networkAdmin/subnetworks.setIamPolicy.
+    "compute.subnetworks.use",
     "batch.jobs.create",
     "batch.jobs.get",
     "batch.jobs.delete",
@@ -115,16 +120,6 @@ resource "google_compute_router_nat" "scanner" {
   region                             = var.region
   nat_ip_allocate_option             = "AUTO_ONLY"
   source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
-}
-
-# Batch runs the worker VM (as the scanner SA) in the subnet above; the SA needs
-# Network User on that subnet to use it.
-resource "google_compute_subnetwork_iam_member" "scanner_network_user" {
-  project    = var.project_id
-  region     = var.region
-  subnetwork = google_compute_subnetwork.scanner.name
-  role       = "roles/compute.networkUser"
-  member     = "serviceAccount:${google_service_account.scanner.email}"
 }
 
 # Orchestrator Cloud Run Job. Workers are created at runtime as Batch jobs, so

--- a/volume-scanner/main.tf
+++ b/volume-scanner/main.tf
@@ -1,0 +1,166 @@
+# Stream Security — GCP agentless volume scanner — Infrastructure Manager
+# Terraform blueprint (DEV-20325).
+#
+# Provisions a single regional orchestrator (Cloud Run Job on a Cloud Scheduler
+# cron) that fans out per-shard workers as GCP Batch jobs; workers snapshot each
+# VM's boot disk, attach it, read it, and clean up. One scanner per project.
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 5.0"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+locals {
+  sa_account_id = "streamsec-volume-scanner"
+  job_name      = "streamsec-volume-scanner-orchestrator"
+  scheduler     = "streamsec-volume-scanner-cron"
+}
+
+# Required APIs.
+resource "google_project_service" "apis" {
+  for_each = toset([
+    "compute.googleapis.com",
+    "batch.googleapis.com",
+    "run.googleapis.com",
+    "cloudscheduler.googleapis.com",
+  ])
+  project            = var.project_id
+  service            = each.key
+  disable_on_destroy = false
+}
+
+# Single service account for orchestrator + worker.
+resource "google_service_account" "scanner" {
+  project      = var.project_id
+  account_id   = local.sa_account_id
+  display_name = "Stream Security volume scanner"
+}
+
+# Combined least-privilege custom role (discover + Batch + snapshot/disk).
+resource "google_project_iam_custom_role" "scanner" {
+  project     = var.project_id
+  role_id     = "streamsecVolumeScanner"
+  title       = "Stream Security Volume Scanner"
+  description = "Agentless disk scanning: discover VMs, snapshot/attach disks, run Batch workers."
+  permissions = [
+    "compute.instances.list",
+    "compute.instances.get",
+    "compute.instances.attachDisk",
+    "compute.instances.detachDisk",
+    "compute.disks.create",
+    "compute.disks.get",
+    "compute.disks.use",
+    "compute.disks.delete",
+    "compute.snapshots.create",
+    "compute.snapshots.get",
+    "compute.snapshots.useReadOnly",
+    "compute.snapshots.delete",
+    "batch.jobs.create",
+    "batch.jobs.get",
+    "batch.jobs.delete",
+    "iam.serviceAccounts.actAs",
+    "logging.logEntries.create",
+  ]
+}
+
+resource "google_project_iam_member" "scanner" {
+  project = var.project_id
+  role    = google_project_iam_custom_role.scanner.id
+  member  = "serviceAccount:${google_service_account.scanner.email}"
+}
+
+# Orchestrator Cloud Run Job. Workers are created at runtime as Batch jobs, so
+# there is no standing worker resource to declare here.
+resource "google_cloud_run_v2_job" "orchestrator" {
+  name     = local.job_name
+  location = var.region
+  project  = var.project_id
+
+  template {
+    template {
+      service_account = google_service_account.scanner.email
+      containers {
+        image = var.scanner_image
+        env {
+          name  = "COLLECTOR_PROVIDER"
+          value = "gcp"
+        }
+        env {
+          name  = "COLLECTOR_ROLE"
+          value = "orchestrator"
+        }
+        env {
+          name  = "COLLECTOR_GCP_PROJECT"
+          value = var.project_id
+        }
+        env {
+          name  = "COLLECTOR_GCP_REGION"
+          value = var.region
+        }
+        env {
+          name  = "COLLECTOR_GCP_WORKER_IMAGE"
+          value = var.scanner_image
+        }
+        env {
+          name  = "COLLECTOR_GCP_WORKER_SA"
+          value = google_service_account.scanner.email
+        }
+        env {
+          name  = "STREAM_SCAN_URL"
+          value = "${var.stream_api_url}/openapi/vulnerabilities/stream_scan/raw"
+        }
+        env {
+          name  = "COLLECTION_TOKEN"
+          value = var.stream_collection_token
+        }
+      }
+    }
+  }
+
+  depends_on = [google_project_service.apis]
+}
+
+# Cloud Scheduler cron -> trigger the orchestrator daily.
+resource "google_cloud_scheduler_job" "cron" {
+  name      = local.scheduler
+  project   = var.project_id
+  region    = var.region
+  schedule  = "0 2 * * *"
+  time_zone = "Etc/UTC"
+
+  http_target {
+    http_method = "POST"
+    uri         = "https://${var.region}-run.googleapis.com/apis/run.googleapis.com/v1/namespaces/${var.project_id}/jobs/${local.job_name}:run"
+    oauth_token {
+      service_account_email = google_service_account.scanner.email
+    }
+  }
+
+  depends_on = [google_cloud_run_v2_job.orchestrator]
+}
+
+# Acknowledge the install back to Stream Security so the console flips the
+# scanner to "deployed". Best-effort: a failure here must not fail the
+# deployment (the orchestrator's first run also re-acks).
+resource "terraform_data" "acknowledge" {
+  triggers_replace = [google_cloud_run_v2_job.orchestrator.uid]
+
+  provisioner "local-exec" {
+    interpreter = ["/bin/sh", "-c"]
+    command     = <<-EOT
+      curl -fsS -X POST "${var.stream_api_url}/api/accounts/${var.project_id}/gcp-scanner-acknowledge" \
+        -H "Content-Type: application/json" \
+        -d '{"customer_id":"${var.stream_customer_id}","project_id":"${var.project_id}","status":"deployed","acknowledge_token":"${var.stream_ack_token}"}' \
+        || echo "ack callback failed (non-fatal); console may show 'pending' until first scan"
+    EOT
+  }
+}

--- a/volume-scanner/main.tf
+++ b/volume-scanner/main.tf
@@ -83,6 +83,16 @@ resource "google_project_iam_member" "scanner" {
   member  = "serviceAccount:${google_service_account.scanner.email}"
 }
 
+# The Batch agent on each worker VM runs as the scanner SA and reports task state
+# to the Batch control plane; that needs roles/batch.agentReporter. Without it
+# the agent starts but can't report, and Batch fails the job with "no VM has
+# agent reporting correctly" (misleadingly looks like an egress problem).
+resource "google_project_iam_member" "scanner_agent_reporter" {
+  project = var.project_id
+  role    = "roles/batch.agentReporter"
+  member  = "serviceAccount:${google_service_account.scanner.email}"
+}
+
 # Dedicated, isolated network for the ephemeral scan workers. They run here with
 # NO external IP and reach the Batch control plane, Compute API, and the scanner
 # image (Artifact Registry) via Cloud NAT. This makes egress part of the

--- a/volume-scanner/main.tf
+++ b/volume-scanner/main.tf
@@ -60,6 +60,12 @@ resource "google_project_iam_custom_role" "scanner" {
     "compute.disks.get",
     "compute.disks.use",
     "compute.disks.delete",
+    # Snapshotting a disk is authorized by compute.disks.createSnapshot ON THE
+    # SOURCE DISK — not compute.snapshots.create (which alone yields
+    # PERMISSION_DENIED on disks.createSnapshot). Both are required: the former
+    # to read-snapshot the source boot disk, the latter to create the snapshot
+    # resource.
+    "compute.disks.createSnapshot",
     "compute.snapshots.create",
     "compute.snapshots.get",
     "compute.snapshots.useReadOnly",

--- a/volume-scanner/main.tf
+++ b/volume-scanner/main.tf
@@ -182,15 +182,27 @@ resource "google_cloud_run_v2_job" "orchestrator" {
           name  = "COLLECTOR_GCP_WORKER_SUBNETWORK"
           value = google_compute_subnetwork.scanner.id
         }
+        # Stream scan ingest — the collector config reads these COLLECTOR_STREAM_*
+        # names (LoadFromEnv); the worker inherits them via the launcher so it can
+        # upload SBOMs + heartbeat.
         env {
-          name  = "STREAM_SCAN_URL"
+          name  = "COLLECTOR_STREAM_SCAN_URL"
           value = "${var.stream_api_url}/openapi/vulnerabilities/stream_scan/raw"
         }
         env {
-          name  = "COLLECTION_TOKEN"
+          name  = "COLLECTOR_STREAM_SCAN_TOKEN"
           value = var.stream_collection_token
         }
-        # For the orchestrator's first-run "deployed" acknowledgement.
+        env {
+          name  = "COLLECTOR_STREAM_SCAN_WORKSPACE"
+          value = var.stream_customer_id
+        }
+        env {
+          name  = "COLLECTOR_STREAM_API_URL"
+          value = var.stream_api_url
+        }
+        # For the orchestrator's first-run "deployed" acknowledgement (read
+        # directly from env by ackGCPDeployedBestEffort, not via config).
         env {
           name  = "STREAM_API_URL"
           value = var.stream_api_url

--- a/volume-scanner/main.tf
+++ b/volume-scanner/main.tf
@@ -161,10 +161,15 @@ resource "google_cloud_run_v2_job" "orchestrator" {
         # Subnet (with Cloud NAT, above) the Batch worker runs in — no external
         # IP; egress via NAT. Makes locked-down projects work without customer
         # networking changes.
+        # Batch requires BOTH network and subnetwork when the worker has no
+        # external IP. Pass the relative form (projects/..) — Batch rejects the
+        # full https self_link.
         env {
-          name = "COLLECTOR_GCP_WORKER_SUBNETWORK"
-          # Relative form (projects/../regions/../subnetworks/..) — GCP Batch
-          # rejects the full https self_link on NetworkInterface.subnetwork.
+          name  = "COLLECTOR_GCP_WORKER_NETWORK"
+          value = google_compute_network.scanner.id
+        }
+        env {
+          name  = "COLLECTOR_GCP_WORKER_SUBNETWORK"
           value = google_compute_subnetwork.scanner.id
         }
         env {

--- a/volume-scanner/main.tf
+++ b/volume-scanner/main.tf
@@ -67,6 +67,9 @@ resource "google_project_iam_custom_role" "scanner" {
     # resource.
     "compute.disks.createSnapshot",
     "compute.snapshots.create",
+    # The snapshot is created with a Purpose label (so the cleanup GC can find
+    # its own orphans) — labeling on create requires compute.snapshots.setLabels.
+    "compute.snapshots.setLabels",
     "compute.snapshots.get",
     "compute.snapshots.useReadOnly",
     "compute.snapshots.delete",

--- a/volume-scanner/main.tf
+++ b/volume-scanner/main.tf
@@ -73,6 +73,16 @@ resource "google_project_iam_custom_role" "scanner" {
     "compute.snapshots.get",
     "compute.snapshots.useReadOnly",
     "compute.snapshots.delete",
+    # Every snapshot/disk/attach call returns an async operation the worker
+    # must poll to completion. Polling needs the *Operations.get permission for
+    # the operation's scope (zonal for disk/attach/createSnapshot, global for
+    # snapshot delete). Without these the create/attach calls succeed on the
+    # server but the client's wait is denied — the scan dies right after
+    # createSnapshot and never creates/attaches the disk (the denial is a read,
+    # so it doesn't even appear in the admin-activity audit log).
+    "compute.zoneOperations.get",
+    "compute.globalOperations.get",
+    "compute.regionOperations.get",
     # Use the scanner's own subnet (below) for the Batch worker VM. Granted via
     # this project-level role rather than a subnet-scoped IAM binding, so the
     # runner SA only needs its documented roles (editor + projectIamAdmin) and

--- a/volume-scanner/main.tf
+++ b/volume-scanner/main.tf
@@ -122,6 +122,19 @@ resource "google_cloud_run_v2_job" "orchestrator" {
           name  = "COLLECTION_TOKEN"
           value = var.stream_collection_token
         }
+        # For the orchestrator's first-run "deployed" acknowledgement.
+        env {
+          name  = "STREAM_API_URL"
+          value = var.stream_api_url
+        }
+        env {
+          name  = "STREAM_CUSTOMER_ID"
+          value = var.stream_customer_id
+        }
+        env {
+          name  = "STREAM_ACK_TOKEN"
+          value = var.stream_ack_token
+        }
       }
     }
   }

--- a/volume-scanner/main.tf
+++ b/volume-scanner/main.tf
@@ -162,8 +162,10 @@ resource "google_cloud_run_v2_job" "orchestrator" {
         # IP; egress via NAT. Makes locked-down projects work without customer
         # networking changes.
         env {
-          name  = "COLLECTOR_GCP_WORKER_SUBNETWORK"
-          value = google_compute_subnetwork.scanner.self_link
+          name = "COLLECTOR_GCP_WORKER_SUBNETWORK"
+          # Relative form (projects/../regions/../subnetworks/..) — GCP Batch
+          # rejects the full https self_link on NetworkInterface.subnetwork.
+          value = google_compute_subnetwork.scanner.id
         }
         env {
           name  = "STREAM_SCAN_URL"

--- a/volume-scanner/main.tf
+++ b/volume-scanner/main.tf
@@ -78,6 +78,55 @@ resource "google_project_iam_member" "scanner" {
   member  = "serviceAccount:${google_service_account.scanner.email}"
 }
 
+# Dedicated, isolated network for the ephemeral scan workers. They run here with
+# NO external IP and reach the Batch control plane, Compute API, and the scanner
+# image (Artifact Registry) via Cloud NAT. This makes egress part of the
+# integration: a locked-down project (external IPs blocked by org policy, no
+# pre-existing Cloud NAT) works out of the box, and nothing touches the
+# customer's own VPCs. Without it, Batch VMs fail with "no VM has agent
+# reporting correctly" before the container ever starts.
+resource "google_compute_network" "scanner" {
+  project                 = var.project_id
+  name                    = "streamsec-scanner-vpc"
+  auto_create_subnetworks = false
+  depends_on              = [google_project_service.apis]
+}
+
+resource "google_compute_subnetwork" "scanner" {
+  project                  = var.project_id
+  name                     = "streamsec-scanner-subnet"
+  region                   = var.region
+  network                  = google_compute_network.scanner.id
+  ip_cidr_range            = "10.61.0.0/24"
+  private_ip_google_access = true
+}
+
+resource "google_compute_router" "scanner" {
+  project = var.project_id
+  name    = "streamsec-scanner-router"
+  region  = var.region
+  network = google_compute_network.scanner.id
+}
+
+resource "google_compute_router_nat" "scanner" {
+  project                            = var.project_id
+  name                               = "streamsec-scanner-nat"
+  router                             = google_compute_router.scanner.name
+  region                             = var.region
+  nat_ip_allocate_option             = "AUTO_ONLY"
+  source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
+}
+
+# Batch runs the worker VM (as the scanner SA) in the subnet above; the SA needs
+# Network User on that subnet to use it.
+resource "google_compute_subnetwork_iam_member" "scanner_network_user" {
+  project    = var.project_id
+  region     = var.region
+  subnetwork = google_compute_subnetwork.scanner.name
+  role       = "roles/compute.networkUser"
+  member     = "serviceAccount:${google_service_account.scanner.email}"
+}
+
 # Orchestrator Cloud Run Job. Workers are created at runtime as Batch jobs, so
 # there is no standing worker resource to declare here.
 resource "google_cloud_run_v2_job" "orchestrator" {
@@ -113,6 +162,13 @@ resource "google_cloud_run_v2_job" "orchestrator" {
         env {
           name  = "COLLECTOR_GCP_WORKER_SA"
           value = google_service_account.scanner.email
+        }
+        # Subnet (with Cloud NAT, above) the Batch worker runs in — no external
+        # IP; egress via NAT. Makes locked-down projects work without customer
+        # networking changes.
+        env {
+          name  = "COLLECTOR_GCP_WORKER_SUBNETWORK"
+          value = google_compute_subnetwork.scanner.self_link
         }
         env {
           name  = "STREAM_SCAN_URL"

--- a/volume-scanner/main.tf
+++ b/volume-scanner/main.tf
@@ -59,6 +59,10 @@ resource "google_project_iam_custom_role" "scanner" {
     "compute.disks.create",
     "compute.disks.get",
     "compute.disks.use",
+    # The scratch disk is attached to the worker in READ_ONLY mode (safer — the
+    # scanner never writes to it), which GCP authorizes via
+    # compute.disks.useReadOnly, not compute.disks.use.
+    "compute.disks.useReadOnly",
     "compute.disks.delete",
     # Snapshotting a disk is authorized by compute.disks.createSnapshot ON THE
     # SOURCE DISK — not compute.snapshots.create (which alone yields

--- a/volume-scanner/variables.tf
+++ b/volume-scanner/variables.tf
@@ -19,8 +19,12 @@ variable "region" {
 
 variable "scanner_image" {
   type        = string
-  description = "Public scanner container image (orchestrator + worker)."
-  default     = "public.ecr.aws/stream-security/volume-scanner:latest"
+  # GCP Cloud Run only pulls from Artifact Registry / gcr.io / docker.io, NOT
+  # public.ecr.aws — so the GCP image is hosted in a Stream-owned public AR
+  # (mirrored there by the cloud-volume-scanner-build release pipeline). The
+  # console always passes an explicit value; this default is just a fallback.
+  description = "Public scanner container image (orchestrator + worker), in a GCP-pullable registry."
+  default     = "us-docker.pkg.dev/stream-secops-project/streamsec-public/volume-scanner:latest"
 }
 
 variable "stream_api_url" {

--- a/volume-scanner/variables.tf
+++ b/volume-scanner/variables.tf
@@ -1,0 +1,46 @@
+# Stream Security — GCP agentless volume scanner — Infrastructure Manager
+# Terraform blueprint inputs (DEV-20325).
+#
+# Deployed via Infrastructure Manager (the successor to Deployment Manager,
+# which is EOL), matching how the Stream GCP integration onboards. The Stream
+# console renders a `gcloud infra-manager deployments apply ...` command
+# pre-filled with these values.
+
+variable "project_id" {
+  type        = string
+  description = "GCP project to scan."
+}
+
+variable "region" {
+  type        = string
+  description = "Region for the orchestrator Cloud Run Job + Cloud Scheduler."
+  default     = "us-central1"
+}
+
+variable "scanner_image" {
+  type        = string
+  description = "Public scanner container image (orchestrator + worker)."
+  default     = "public.ecr.aws/stream-security/volume-scanner:latest"
+}
+
+variable "stream_api_url" {
+  type        = string
+  description = "Stream Security tenant API URL, e.g. https://<tenant>.<domain>."
+}
+
+variable "stream_customer_id" {
+  type        = string
+  description = "Stream Security workspace (customer) id."
+}
+
+variable "stream_ack_token" {
+  type        = string
+  description = "Per-deployment acknowledge token (authenticates install callback)."
+  sensitive   = true
+}
+
+variable "stream_collection_token" {
+  type        = string
+  description = "Per-customer collection token (authenticates scan reports)."
+  sensitive   = true
+}


### PR DESCRIPTION
## What
Terraform blueprint for the GCP volume scanner, deployed via **Infrastructure Manager** (matches how the Stream GCP integration onboards). The Stream console renders it as a one-command `gcloud infra-manager deployments apply`.

## Provisions (per project)
- **Service account** `streamsec-volume-scanner` + least-privilege **custom role** `streamsecVolumeScanner` + project binding.
- **Isolated worker network** — VPC `streamsec-scanner-vpc` + subnet + Cloud Router + **Cloud NAT**, so the no-external-IP Batch workers get egress **without the customer touching their own VPCs**. Subnet access is granted via the project-level custom role (`compute.subnetworks.use`), not a subnet IAM binding, so the runner SA needs only editor + IAM-admin (no `networkAdmin`).
- Orchestrator **Cloud Run Job** (image + env, incl. `COLLECTOR_GCP_WORKER_NETWORK`/`_SUBNETWORK` in relative form).
- **Cloud Scheduler** daily cron → runs the orchestrator.
- Post-apply **acknowledgement** back to Stream (best-effort; non-fatal).

## Notes
- `variables.tf` `scanner_image` default → the Stream-owned **public Artifact Registry** (GCP Cloud Run can't pull `public.ecr.aws`).
- README documents the **deny-all-egress prerequisite**: projects that enforce an org/hierarchical egress deny must allow the scanner subnet's egress to Google APIs (a NAT can't override an org-level deny).

## Related
lightlytics#20860 (console/backend), cloud-volume-scanner#20 (provider/image), platform-jenkins#465 (image mirror to the AR).