### PR TITLE
streamforce: add custom-plugin Cloud Run deploy script + walkthrough

### DIFF
--- a/streamforce-plugin-deploy.sh
+++ b/streamforce-plugin-deploy.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+#
+# Stream Security — StreamForce custom-plugin deploy for GCP.
+#
+# Deploys a customer's plugin as a PRIVATE (IAM-gated) Cloud Run service in the
+# current project, grants the Stream Security service account run.invoker, and
+# acknowledges the service URL back to the platform. The plugin's env values are
+# passed on the command line (from the Stream wizard) straight into the Cloud Run
+# service — they never pass through the Stream platform.
+#
+# Usage (copy the exact command from the Stream Security plugin wizard):
+#   bash streamforce-plugin-deploy.sh \
+#     --plugin-id <id> --region <region> --artifact-url <url> \
+#     --plugin-token <token> --platform-url <url> --sa-email <sa> \
+#     --env '{"KEY":"value"}'
+#
+set -euo pipefail
+
+PLUGIN_ID=""
+REGION="us-central1"
+ARTIFACT_URL=""
+PLUGIN_TOKEN=""
+PLATFORM_URL=""
+SA_EMAIL=""
+PLUGIN_ENV="{}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --plugin-id)    PLUGIN_ID="$2"; shift 2 ;;
+    --region)       REGION="$2"; shift 2 ;;
+    --artifact-url) ARTIFACT_URL="$2"; shift 2 ;;
+    --plugin-token) PLUGIN_TOKEN="$2"; shift 2 ;;
+    --platform-url) PLATFORM_URL="$2"; shift 2 ;;
+    --sa-email)     SA_EMAIL="$2"; shift 2 ;;
+    --env)          PLUGIN_ENV="$2"; shift 2 ;;
+    *) echo "Unknown argument: $1" >&2; exit 1 ;;
+  esac
+done
+
+for var in PLUGIN_ID ARTIFACT_URL PLUGIN_TOKEN PLATFORM_URL SA_EMAIL; do
+  if [[ -z "${!var}" ]]; then
+    echo "Missing required argument for ${var}" >&2
+    exit 1
+  fi
+done
+
+SERVICE="sfplugin-${PLUGIN_ID:0:8}"
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+echo "==> Downloading plugin artifact"
+curl -fsSL "$ARTIFACT_URL" -o "$WORKDIR/plugin.zip"
+mkdir -p "$WORKDIR/src"
+unzip -q "$WORKDIR/plugin.zip" -d "$WORKDIR/src"
+
+echo "==> Deploying private Cloud Run service: $SERVICE (region $REGION)"
+# `^@@^` sets @@ as the env-var delimiter so commas inside PLUGIN_ENV_JSON are
+# not misread as separators. PLUGIN_ENV_JSON is expanded into process.env by the
+# plugin's entrypoint at startup.
+gcloud run deploy "$SERVICE" \
+  --source "$WORKDIR/src" \
+  --region "$REGION" \
+  --no-allow-unauthenticated \
+  --set-env-vars "^@@^PLUGIN_ID=${PLUGIN_ID}@@PLUGIN_TOKEN=${PLUGIN_TOKEN}@@PLATFORM_URL=${PLATFORM_URL}@@PLUGIN_ENV_JSON=${PLUGIN_ENV}" \
+  --quiet
+
+echo "==> Granting ${SA_EMAIL} the run.invoker role on ${SERVICE}"
+gcloud run services add-iam-policy-binding "$SERVICE" \
+  --region "$REGION" \
+  --member="serviceAccount:${SA_EMAIL}" \
+  --role="roles/run.invoker" \
+  --quiet
+
+URL="$(gcloud run services describe "$SERVICE" --region "$REGION" --format='value(status.url)')"
+echo "==> Service URL: $URL"
+
+echo "==> Acknowledging to Stream Security"
+curl -fsS -X POST "${PLATFORM_URL%/}/api/accounts/streamforce-plugins/acknowledge" \
+  -H "Authorization: Bearer ${PLUGIN_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d "{\"function_url\": \"${URL}\"}"
+
+echo
+echo "✅ Plugin deployed. It will show as Active in Stream Security once its tools are reachable."

--- a/streamforce-plugin-walkthrough.md
+++ b/streamforce-plugin-walkthrough.md
@@ -1,0 +1,50 @@
+# Deploy a StreamForce plugin to Google Cloud
+
+This walkthrough deploys a Stream Security **StreamForce custom plugin** as a
+private Cloud Run service in your project. The service is IAM-gated
+(`--no-allow-unauthenticated`) and only the Stream Security service account is
+granted permission to invoke it.
+
+## Select a project
+
+<walkthrough-project-setup></walkthrough-project-setup>
+
+```sh
+gcloud config set project <walkthrough-project-id/>
+```
+
+## Enable the required APIs
+
+The deploy source-builds a container (Cloud Build) and runs it on Cloud Run.
+
+<walkthrough-enable-apis apis="run.googleapis.com,cloudbuild.googleapis.com,artifactregistry.googleapis.com"></walkthrough-enable-apis>
+
+## Run the deploy command
+
+Copy the command from the Stream Security plugin wizard and paste it into the
+terminal. It already contains your plugin id, artifact URL, callback token,
+service account, and environment values.
+
+```sh
+bash streamforce-plugin-deploy.sh \
+  --plugin-id {{ PLUGIN_ID }} \
+  --region {{ REGION }} \
+  --artifact-url {{ ARTIFACT_URL }} \
+  --plugin-token {{ PLUGIN_TOKEN }} \
+  --platform-url {{ PLATFORM_URL }} \
+  --sa-email {{ SA_EMAIL }} \
+  --env '{{ PLUGIN_ENV_JSON }}'
+```
+
+The script will:
+
+1. Download the plugin package.
+2. Deploy a **private** Cloud Run service (`sfplugin-<id>`).
+3. Grant the Stream Security service account `roles/run.invoker`.
+4. Report the service URL back to Stream Security.
+
+## Verify
+
+Go back to the Stream Security console. The plugin flips to **Active** once its
+tools are reachable — its operations then appear as tools under
+**Custom Plugins** in the agent builder.


### PR DESCRIPTION
Deploys a StreamForce custom plugin as a private (IAM-gated) Cloud Run service, grants the Stream Security service account run.invoker, and acknowledges the service URL back to the platform. Env values are passed on the command line straight into the deploy — never through the platform.